### PR TITLE
Add configurable S3 thumbnail storage support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -49,6 +49,14 @@ BACKBLAZE_SECRET_KEY=your_application_key_secret_here
 # Older thumbnails will be automatically deleted to save disk space
 THUMBNAIL_MAX_AGE_DAYS=30
 
+# Where to store generated thumbnails: 'local' keeps them on disk, 's3' saves
+# them back into your Backblaze/S3 bucket under the prefix below.
+THUMBNAIL_STORAGE=local
+
+# When using S3 thumbnail storage, generated thumbnails are saved under this
+# prefix (relative to your bucket). Defaults to `thumbnails`.
+THUMBNAIL_S3_PREFIX=thumbnails
+
 # How often to automatically sync with Backblaze in hours (default: 24)
 # Set to 0 to disable automatic sync (manual sync only)
 SYNC_INTERVAL_HOURS=24

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ A self-hosted photo gallery that integrates with *Backblaze B2* cloud storage (o
 4. **Access your gallery**
    Open http://localhost:3000 and your photos will be automatically scanned and indexed
 
+### Thumbnail storage configuration
+
+Blaze Gallery generates lightweight thumbnails for fast browsing. By default they
+are stored on the local filesystem inside `data/thumbnails`. To keep your
+deployment fully stateless you can instruct the app to write thumbnails back to
+the same S3-compatible bucket that contains your photos:
+
+```env
+# Save thumbnails alongside your photos in S3 instead of local disk
+THUMBNAIL_STORAGE=s3
+THUMBNAIL_S3_PREFIX=thumbnails
+```
+
+Thumbnails are stored in a dedicated prefix (default `thumbnails/`) that mirrors
+your original folder structure and appends the internal photo ID to the file
+name to avoid collisions (e.g. `thumbnails/vacation/IMG_0001-42.jpeg`).
+
 ## AI Integration (MCP Server)
 
 Blaze Gallery includes an **MCP (Model Context Protocol) server** that lets you query your photo collection using natural language with Claude and other AI assistants.

--- a/src/lib/thumbnails.ts
+++ b/src/lib/thumbnails.ts
@@ -1,22 +1,72 @@
 import sharp from "sharp";
 import path from "path";
 import fs from "fs";
-import { getObjectStream } from "./s3";
+import {
+  deleteObject,
+  getObjectMetadata,
+  getObjectStream,
+  listObjects,
+  putObject,
+  S3Object,
+} from "./s3";
 import { updatePhotoThumbnail } from "./database";
 import { getConfig } from "./config";
 import { logger } from "./logger";
 import { ThumbnailOptions, ThumbnailStats } from "@/types/common";
 
 export function getThumbnailsPath(customPath?: string): string {
-  return customPath ||
-         process.env.THUMBNAILS_PATH ||
-         path.join(process.cwd(), "data", "thumbnails");
+  return (
+    customPath ||
+    process.env.THUMBNAILS_PATH ||
+    path.join(process.cwd(), "data", "thumbnails")
+  );
+}
+
+export interface ThumbnailStorageInfo {
+  mode: "local" | "s3";
+  location: string;
+  prefix?: string;
+  bucket?: string;
+}
+
+export function normalizeThumbnailS3Prefix(prefix?: string): string {
+  const fallback = "thumbnails";
+  if (!prefix) {
+    return fallback;
+  }
+
+  const trimmed = prefix.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  const sanitized = trimmed.replace(/^\/+/g, "").replace(/\/+$/g, "");
+  return sanitized || fallback;
+}
+
+export function getThumbnailStorageInfo(): ThumbnailStorageInfo {
+  const config = getConfig();
+
+  if (config.thumbnail_storage === "s3") {
+    const prefix = normalizeThumbnailS3Prefix(config.thumbnail_s3_prefix);
+    return {
+      mode: "s3",
+      location: `s3://${config.backblaze_bucket}/${prefix}`,
+      prefix,
+      bucket: config.backblaze_bucket,
+    };
+  }
+
+  const localPath = getThumbnailsPath();
+  return { mode: "local", location: localPath };
 }
 
 export function getDatabasePath(customPath?: string): string {
-  return customPath ||
-         process.env.DATABASE_PATH ||
-         path.join(process.cwd(), "data", "database", "gallery.db");
+  return (
+    customPath ||
+    process.env.DATABASE_PATH ||
+    path.join(process.cwd(), "data", "database", "gallery.db")
+  );
 }
 
 const DEFAULT_THUMBNAIL_OPTIONS: Required<ThumbnailOptions> = {
@@ -28,16 +78,135 @@ const DEFAULT_THUMBNAIL_OPTIONS: Required<ThumbnailOptions> = {
 
 export class ThumbnailService {
   private thumbnailsDir: string;
+  private storageMode: "local" | "s3";
+  private s3Prefix: string;
+  private s3ListPrefix: string;
+  private bucket: string;
 
   constructor(thumbnailsDir?: string) {
-    this.thumbnailsDir = getThumbnailsPath(thumbnailsDir);
+    const config = getConfig();
+    this.storageMode = config.thumbnail_storage;
+    this.bucket = config.backblaze_bucket;
+    this.s3Prefix = normalizeThumbnailS3Prefix(config.thumbnail_s3_prefix);
+    this.s3ListPrefix = this.s3Prefix ? `${this.s3Prefix}/` : "";
+    this.thumbnailsDir = thumbnailsDir || getThumbnailsPath();
+
     this.ensureThumbnailsDirectory();
   }
 
   private ensureThumbnailsDirectory() {
+    if (this.storageMode !== "local") {
+      return;
+    }
+
     if (!fs.existsSync(this.thumbnailsDir)) {
       fs.mkdirSync(this.thumbnailsDir, { recursive: true });
     }
+  }
+
+  private isS3Storage(): boolean {
+    return this.storageMode === "s3";
+  }
+
+  private getS3ThumbnailKey(
+    photoId: number,
+    format: string,
+    originalKey: string,
+  ): string {
+    const normalizedOriginal = originalKey.replace(/^\/+/, "");
+    const dir = path.posix.dirname(normalizedOriginal);
+    const baseName = path.posix.basename(
+      normalizedOriginal,
+      path.posix.extname(normalizedOriginal),
+    );
+    const fileName = `${baseName}-${photoId}.${format}`;
+
+    const segments = [] as string[];
+    if (this.s3Prefix) {
+      segments.push(this.s3Prefix);
+    }
+    if (dir && dir !== ".") {
+      segments.push(dir);
+    }
+    segments.push(fileName);
+
+    return path.posix.join(...segments.filter(Boolean));
+  }
+
+  private isNotFoundError(error: unknown): boolean {
+    if (!error || typeof error !== "object") {
+      return false;
+    }
+
+    const metadata = (error as any).$metadata;
+    if (metadata?.httpStatusCode === 404) {
+      return true;
+    }
+
+    const name = (error as any).name;
+    const code = (error as any).Code || (error as any).code;
+    return name === "NotFound" || code === "NotFound";
+  }
+
+  private async doesThumbnailExist(location: string): Promise<boolean> {
+    if (!this.isS3Storage()) {
+      return fs.existsSync(location);
+    }
+
+    try {
+      await getObjectMetadata(this.bucket, location);
+      return true;
+    } catch (error) {
+      if (this.isNotFoundError(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private async writeThumbnail(
+    thumbnailPath: string,
+    buffer: Buffer,
+  ): Promise<void> {
+    if (!this.isS3Storage()) {
+      await fs.promises.writeFile(thumbnailPath, buffer);
+      return;
+    }
+
+    await putObject(this.bucket, thumbnailPath, buffer, {
+      contentType: "image/jpeg",
+      cacheControl: "public, max-age=31536000, immutable",
+    });
+  }
+
+  private async listAllThumbnails(): Promise<S3Object[]> {
+    if (!this.isS3Storage()) {
+      return [];
+    }
+
+    const allObjects: S3Object[] = [];
+    let continuationToken: string | undefined;
+    let pageNumber = 1;
+
+    do {
+      const { objects, nextContinuationToken, isTruncated } = await listObjects(
+        this.bucket,
+        this.s3ListPrefix || undefined,
+        continuationToken,
+        1000,
+        pageNumber,
+      );
+
+      allObjects.push(...objects);
+      continuationToken = nextContinuationToken;
+      pageNumber += 1;
+
+      if (!isTruncated) {
+        break;
+      }
+    } while (continuationToken);
+
+    return allObjects;
   }
 
   async generateThumbnail(
@@ -49,16 +218,27 @@ export class ThumbnailService {
     request?: Request,
   ): Promise<string> {
     const opts = { ...DEFAULT_THUMBNAIL_OPTIONS, ...options };
-    const thumbnailPath = this.getThumbnailPath(photoId, opts.format);
+    const thumbnailPath = this.getThumbnailPath(photoId, opts.format, s3Key);
 
-    if (fs.existsSync(thumbnailPath)) {
-      await updatePhotoThumbnail(photoId, thumbnailPath);
-      return thumbnailPath;
+    try {
+      if (await this.doesThumbnailExist(thumbnailPath)) {
+        await updatePhotoThumbnail(photoId, thumbnailPath);
+        return thumbnailPath;
+      }
+    } catch (error) {
+      logger.thumbnailError(
+        "Failed to check existing thumbnail",
+        error as Error,
+        {
+          photoId,
+          thumbnailPath,
+        },
+      );
+      // Continue with generation attempt after logging
     }
 
     // Check size threshold unless bypassed
     if (!bypassSizeCheck) {
-      const { getConfig } = await import("./config");
       const { getPhoto } = await import("./database");
 
       const config = getConfig();
@@ -77,7 +257,6 @@ export class ThumbnailService {
             },
           );
 
-          // Update status to indicate it was skipped due to size
           const { updatePhotoStatus } = await import("./database");
           await updatePhotoStatus(photoId, {
             thumbnail_status: "skipped_size",
@@ -91,8 +270,10 @@ export class ThumbnailService {
     }
 
     try {
-      const filename = s3Key.split('/').pop() || s3Key;
-      logger.debug(`[THUMBNAIL] Generating thumbnail for ${filename} (ID: ${photoId})`);
+      const filename = s3Key.split("/").pop() || s3Key;
+      logger.debug(
+        `[THUMBNAIL] Generating thumbnail for ${filename} (ID: ${photoId})`,
+      );
 
       const stream = await getObjectStream(bucket, s3Key, request);
       if (!stream) {
@@ -119,29 +300,32 @@ export class ThumbnailService {
 
       const inputBuffer = Buffer.concat(chunks);
 
-      await sharp(inputBuffer)
+      const thumbnailBuffer = await sharp(inputBuffer)
         .resize(opts.width, opts.height, {
           fit: "inside",
           withoutEnlargement: true,
         })
         .jpeg({ quality: opts.quality })
-        .toFile(thumbnailPath);
+        .toBuffer();
 
+      await this.writeThumbnail(thumbnailPath, thumbnailBuffer);
       await updatePhotoThumbnail(photoId, thumbnailPath);
 
-      logger.debug(`[THUMBNAIL] Generated thumbnail for ${filename} (ID: ${photoId})`);
+      logger.debug(
+        `[THUMBNAIL] Generated thumbnail for ${filename} (ID: ${photoId})`,
+      );
 
       return thumbnailPath;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      
-      // Check for corrupted JPEG files
-      if (errorMessage.includes('VipsJpeg: Invalid SOS parameters') || 
-          errorMessage.includes('Invalid SOS parameters for sequential JPEG') ||
-          errorMessage.includes('VipsJpeg:') ||
-          errorMessage.includes('premature end of JPEG file') ||
-          errorMessage.includes('JPEG datastream contains no image')) {
-        
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+
+      if (
+        errorMessage.includes("VipsJpeg: Invalid SOS parameters") ||
+        errorMessage.includes("Invalid SOS parameters for sequential JPEG") ||
+        errorMessage.includes("VipsJpeg:") ||
+        errorMessage.includes("premature end of JPEG file") ||
+        errorMessage.includes("JPEG datastream contains no image")
+      ) {
         logger.thumbnailOperation(
           `Thumbnail generation skipped - corrupted JPEG file`,
           {
@@ -150,24 +334,22 @@ export class ThumbnailService {
           },
         );
 
-        // Update status to indicate it was skipped due to corruption
         const { updatePhotoStatus } = await import("./database");
         await updatePhotoStatus(photoId, {
           thumbnail_status: "skipped_corrupted",
         });
 
-        // Don't throw error - just skip this photo and continue
         logger.debug(`[THUMBNAIL] Skipping corrupted JPEG: ${s3Key}`);
-        return '';
+        return "";
       }
-      
-      // Check for unsupported format errors
-      if (errorMessage.includes('Input file contains unsupported image format') || 
-          errorMessage.includes('unsupported image format') ||
-          errorMessage.includes('Input buffer contains unsupported image format')) {
-        
-        const fileExt = s3Key.toLowerCase().split('.').pop() || 'unknown';
-        
+
+      if (
+        errorMessage.includes("Input file contains unsupported image format") ||
+        errorMessage.includes("unsupported image format") ||
+        errorMessage.includes("Input buffer contains unsupported image format")
+      ) {
+        const fileExt = s3Key.toLowerCase().split(".").pop() || "unknown";
+
         logger.thumbnailOperation(
           `Thumbnail generation skipped - unsupported format: ${fileExt}`,
           {
@@ -176,16 +358,16 @@ export class ThumbnailService {
           },
         );
 
-        // Update status to indicate it was skipped due to unsupported format
         const { updatePhotoStatus } = await import("./database");
         await updatePhotoStatus(photoId, {
           thumbnail_status: "skipped_unsupported",
         });
 
-        throw new Error(`Unsupported image format: ${fileExt.toUpperCase()} files are not supported by Sharp for thumbnail generation`);
+        throw new Error(
+          `Unsupported image format: ${fileExt.toUpperCase()} files are not supported by Sharp for thumbnail generation`,
+        );
       }
 
-      // Log other errors as before
       logger.thumbnailError(
         "Error generating thumbnail for photo",
         error as Error,
@@ -198,35 +380,91 @@ export class ThumbnailService {
     }
   }
 
-  async getThumbnailBuffer(thumbnailPath: string): Promise<Buffer | null> {
+  async getThumbnailBuffer(
+    thumbnailPath: string,
+    request?: Request,
+  ): Promise<Buffer | null> {
     try {
-      if (!fs.existsSync(thumbnailPath)) {
+      if (!this.isS3Storage()) {
+        if (!fs.existsSync(thumbnailPath)) {
+          return null;
+        }
+
+        return fs.readFileSync(thumbnailPath);
+      }
+
+      const stream = await getObjectStream(this.bucket, thumbnailPath, request);
+      if (!stream) {
         return null;
       }
 
-      return fs.readFileSync(thumbnailPath);
-    } catch (error) {
-      logger.thumbnailError("Error reading thumbnail file", error as Error, {
-        thumbnailPath,
+      const chunks: Buffer[] = [];
+      await new Promise<void>((resolve, reject) => {
+        if (stream && typeof stream === "object" && "on" in stream) {
+          (stream as any).on("data", (chunk: Buffer) => {
+            chunks.push(Buffer.from(chunk));
+          });
+          (stream as any).on("end", () => resolve());
+          (stream as any).on("error", (error: Error) => reject(error));
+        } else {
+          reject(new Error("Invalid stream type from S3"));
+        }
       });
+
+      return Buffer.concat(chunks);
+    } catch (error) {
+      logger.thumbnailError(
+        "Error reading thumbnail file",
+        error as Error,
+        {
+          thumbnailPath,
+        },
+      );
       return null;
     }
   }
 
-  getThumbnailPath(photoId: number, format: string = "jpeg"): string {
+  getThumbnailPath(
+    photoId: number,
+    format: string = "jpeg",
+    originalKey?: string,
+  ): string {
+    if (this.isS3Storage()) {
+      if (!originalKey) {
+        throw new Error("Original S3 key is required for S3 thumbnail storage");
+      }
+      return this.getS3ThumbnailKey(photoId, format, originalKey);
+    }
+
     return path.join(this.thumbnailsDir, `${photoId}.${format}`);
   }
 
   async deleteThumbnail(thumbnailPath: string): Promise<void> {
     try {
+      if (!thumbnailPath) {
+        return;
+      }
+
+      if (this.isS3Storage()) {
+        await deleteObject(this.bucket, thumbnailPath);
+        logger.thumbnailOperation("Deleted thumbnail object from S3", {
+          thumbnailPath,
+        });
+        return;
+      }
+
       if (fs.existsSync(thumbnailPath)) {
         fs.unlinkSync(thumbnailPath);
         logger.thumbnailOperation("Deleted thumbnail file");
       }
     } catch (error) {
-      logger.thumbnailError("Error deleting thumbnail file", error as Error, {
-        thumbnailPath,
-      });
+      logger.thumbnailError(
+        "Error deleting thumbnail file",
+        error as Error,
+        {
+          thumbnailPath,
+        },
+      );
     }
   }
 
@@ -283,21 +521,39 @@ export class ThumbnailService {
     let deletedCount = 0;
 
     try {
-      const files = fs.readdirSync(this.thumbnailsDir);
+      if (this.isS3Storage()) {
+        const thumbnails = await this.listAllThumbnails();
 
-      for (const file of files) {
-        const filePath = path.join(this.thumbnailsDir, file);
-        const stats = fs.statSync(filePath);
+        for (const obj of thumbnails) {
+          if (obj.lastModified < cutoffDate) {
+            await deleteObject(this.bucket, obj.key);
+            deletedCount++;
 
-        if (stats.mtime < cutoffDate) {
-          fs.unlinkSync(filePath);
-          deletedCount++;
+            if (deletedCount % 100 === 0) {
+              logger.thumbnailOperation("Cleanup progress update", {
+                deletedCount,
+                maxAgeDays,
+              });
+            }
+          }
+        }
+      } else {
+        const files = fs.readdirSync(this.thumbnailsDir);
 
-          if (deletedCount % 100 === 0) {
-            logger.thumbnailOperation("Cleanup progress update", {
-              deletedCount,
-              maxAgeDays,
-            });
+        for (const file of files) {
+          const filePath = path.join(this.thumbnailsDir, file);
+          const stats = fs.statSync(filePath);
+
+          if (stats.mtime < cutoffDate) {
+            fs.unlinkSync(filePath);
+            deletedCount++;
+
+            if (deletedCount % 100 === 0) {
+              logger.thumbnailOperation("Cleanup progress update", {
+                deletedCount,
+                maxAgeDays,
+              });
+            }
           }
         }
       }
@@ -315,8 +571,34 @@ export class ThumbnailService {
     return deletedCount;
   }
 
-  getThumbnailStats(): ThumbnailStats {
+  async getThumbnailStats(): Promise<ThumbnailStats> {
     try {
+      if (this.isS3Storage()) {
+        const objects = await this.listAllThumbnails();
+        let totalSize = 0;
+        let oldestDate: Date | undefined;
+        let newestDate: Date | undefined;
+
+        for (const obj of objects) {
+          totalSize += obj.size;
+
+          if (!oldestDate || obj.lastModified < oldestDate) {
+            oldestDate = obj.lastModified;
+          }
+
+          if (!newestDate || obj.lastModified > newestDate) {
+            newestDate = obj.lastModified;
+          }
+        }
+
+        return {
+          totalThumbnails: objects.length,
+          totalSize,
+          oldestThumbnail: oldestDate,
+          newestThumbnail: newestDate,
+        };
+      }
+
       const files = fs.readdirSync(this.thumbnailsDir);
       let totalSize = 0;
       let oldestDate: Date | undefined;
@@ -352,20 +634,21 @@ export class ThumbnailService {
     }
   }
 
-  /**
-   * Common thumbnail serving logic for both regular and shared endpoints
-   * Tries existing thumbnail first, generates on-demand if missing
-   */
   async serveThumbnail(
-    photo: any, 
+    photo: any,
     request?: Request,
-    forceGenerate: boolean = false
-  ): Promise<{ buffer: Buffer; headers: Record<string, string> } | { error: string; status: number }> {
+    forceGenerate: boolean = false,
+  ): Promise<
+    | { buffer: Buffer; headers: Record<string, string> }
+    | { error: string; status: number }
+  > {
     const config = getConfig();
-    
-    // First try to serve existing thumbnail
+
     if (photo.thumbnail_path) {
-      const thumbnailBuffer = await this.getThumbnailBuffer(photo.thumbnail_path);
+      const thumbnailBuffer = await this.getThumbnailBuffer(
+        photo.thumbnail_path,
+        request,
+      );
       if (thumbnailBuffer) {
         return {
           buffer: thumbnailBuffer,
@@ -373,12 +656,11 @@ export class ThumbnailService {
             "Content-Type": "image/jpeg",
             "Cache-Control": "public, max-age=31536000, immutable",
             "Content-Length": thumbnailBuffer.length.toString(),
-          }
+          },
         };
       }
     }
 
-    // If no existing thumbnail, generate one on-demand
     let thumbnailPath;
     try {
       thumbnailPath = await this.generateThumbnail(
@@ -390,19 +672,22 @@ export class ThumbnailService {
         request,
       );
     } catch (error) {
-      // Handle unsupported format gracefully
-      if (error instanceof Error && error.message.includes("Unsupported image format")) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Unsupported image format")
+      ) {
         logger.thumbnailOperation(
-          `Thumbnail request for unsupported format: ${photo.s3_key.toLowerCase().split('.').pop() || 'unknown'}`,
+          `Thumbnail request for unsupported format: ${
+            photo.s3_key.toLowerCase().split(".").pop() || "unknown"
+          }`,
           {
             photoId: photo.id,
             s3Key: photo.s3_key,
           },
         );
-        return { error: 'Unsupported image format', status: 415 };
+        return { error: "Unsupported image format", status: 415 };
       }
 
-      // Handle large files
       if (error instanceof Error && error.message.includes("Photo too large")) {
         const sizeMB = photo.size / (1024 * 1024);
         logger.thumbnailOperation(
@@ -413,23 +698,23 @@ export class ThumbnailService {
             s3Key: photo.s3_key,
           },
         );
-        
+
         if (forceGenerate) {
-          return { 
+          return {
             error: `This photo is ${sizeMB.toFixed(1)}MB, which exceeds the ${config.auto_thumbnail_threshold_mb}MB threshold. Add ?force=true to generate anyway.`,
-            status: 413 
+            status: 413,
           };
         } else {
-          return { error: 'Photo too large for thumbnail generation', status: 413 };
+          return { error: "Photo too large for thumbnail generation", status: 413 };
         }
       }
-      
-      throw error; // Re-throw other errors
+
+      throw error;
     }
 
-    const thumbnailBuffer = await this.getThumbnailBuffer(thumbnailPath);
+    const thumbnailBuffer = await this.getThumbnailBuffer(thumbnailPath, request);
     if (!thumbnailBuffer) {
-      return { error: 'Failed to generate thumbnail', status: 500 };
+      return { error: "Failed to generate thumbnail", status: 500 };
     }
 
     return {
@@ -438,7 +723,7 @@ export class ThumbnailService {
         "Content-Type": "image/jpeg",
         "Cache-Control": "public, max-age=31536000, immutable",
         "Content-Length": thumbnailBuffer.length.toString(),
-      }
+      },
     };
   }
 }

--- a/src/scripts/startup.ts
+++ b/src/scripts/startup.ts
@@ -66,7 +66,7 @@ async function performStartup(): Promise<void> {
     }
 
     logger.info("Checking thumbnail service...");
-    const thumbnailStats = thumbnailService.getThumbnailStats();
+    const thumbnailStats = await thumbnailService.getThumbnailStats();
     const sizeMB = (thumbnailStats.totalSize / 1024 / 1024).toFixed(1);
     logger.info(
       `Thumbnails: ${thumbnailStats.totalThumbnails} files (${sizeMB}MB)`,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,8 @@ export interface Config {
   backblaze_bucket: string;
   backblaze_access_key: string;
   backblaze_secret_key: string;
+  thumbnail_storage: "local" | "s3";
+  thumbnail_s3_prefix: string;
   thumbnail_max_age_days: number;
   sync_interval_hours: number;
   auto_metadata_threshold_mb: number;


### PR DESCRIPTION
## Summary
- add configuration options for thumbnail storage mode and S3 prefix
- update thumbnail service to write, read, and clean up objects in S3 when configured and expose storage-aware health/audit data
- document the new environment variables and add a project ESLint config to avoid interactive prompts

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*
- `npm run typecheck` *(fails: pre-existing type errors in src/lib/sync.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ecb503c883289f36556940b94e2a