### PR TITLE
feat: Add photo upload and delete functionality

### DIFF
--- a/src/app/api/photos/[id]/route.ts
+++ b/src/app/api/photos/[id]/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getPhoto } from "@/lib/database";
+import { getPhoto, deletePhoto } from "@/lib/database";
+import { deleteObject } from "@/lib/s3";
+import { thumbnailService } from "@/lib/thumbnails";
+import { getConfig } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { requireAuth } from "@/lib/auth/middleware";
 
@@ -41,6 +44,72 @@ export const GET = requireAuth(async function GET(
       {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+});
+
+export const DELETE = requireAuth(async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const photoId = parseInt(params.id);
+
+    if (isNaN(photoId)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid photo ID" },
+        { status: 400 },
+      );
+    }
+
+    // Get photo to retrieve S3 key and thumbnail path
+    const photo = await getPhoto(photoId);
+
+    if (!photo) {
+      return NextResponse.json(
+        { success: false, error: "Photo not found" },
+        { status: 404 },
+      );
+    }
+
+    const config = getConfig();
+
+    // Delete from S3 (original photo)
+    await deleteObject(config.backblaze_bucket, photo.s3_key, request);
+    logger.info(`Deleted photo from S3: ${photo.s3_key}`);
+
+    // Delete thumbnail if exists
+    if (photo.thumbnail_path) {
+      try {
+        await thumbnailService.deleteThumbnail(photo.thumbnail_path);
+        logger.info(`Deleted thumbnail: ${photo.thumbnail_path}`);
+      } catch (err) {
+        // Log but don't fail if thumbnail deletion fails
+        logger.warn(`Failed to delete thumbnail for photo ${photoId}`, undefined, err instanceof Error ? err : undefined);
+      }
+    }
+
+    // Delete from database
+    await deletePhoto(photoId);
+    logger.info(`Deleted photo from database: ${photoId}`);
+
+    return NextResponse.json({
+      success: true,
+      message: `Photo ${photoId} deleted successfully`,
+    });
+  } catch (error) {
+    const photoId = parseInt(params.id);
+    logger.apiError("Error in DELETE /api/photos/[id]", error as Error, {
+      method: "DELETE",
+      path: "/api/photos/[id]",
+      photoId: photoId,
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Delete failed",
       },
       { status: 500 },
     );

--- a/src/app/api/photos/upload/route.ts
+++ b/src/app/api/photos/upload/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth/middleware";
+import { putObject, getMimeType, isMediaFile } from "@/lib/s3";
+import { createOrUpdatePhoto, getFolderByPath, createOrUpdateFolder } from "@/lib/database";
+import { thumbnailService } from "@/lib/thumbnails";
+import { getConfig } from "@/lib/config";
+import { logger } from "@/lib/logger";
+
+export const POST = requireAuth(async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+    const folderPath = (formData.get("folder") as string) || "";
+
+    if (!file) {
+      return NextResponse.json(
+        { success: false, error: "No file provided" },
+        { status: 400 },
+      );
+    }
+
+    if (!isMediaFile(file.name)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid file type. Only images and videos are allowed." },
+        { status: 400 },
+      );
+    }
+
+    const config = getConfig();
+    const bucket = config.backblaze_bucket;
+
+    // Build S3 key: folder/filename
+    const s3Key = folderPath ? `${folderPath}/${file.name}` : file.name;
+
+    // Get or create folder in DB
+    let folder = await getFolderByPath(folderPath || "/");
+    if (!folder) {
+      // Create folder if it doesn't exist
+      const folderName = folderPath.split("/").pop() || "Root";
+      folder = await createOrUpdateFolder({
+        path: folderPath || "/",
+        name: folderName,
+        parent_id: undefined,
+      });
+    }
+
+    // Read file as buffer
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Upload to S3
+    const mimeType = getMimeType(file.name);
+    await putObject(bucket, s3Key, buffer, {
+      contentType: mimeType,
+      request,
+    });
+
+    logger.info(`Uploaded photo to S3: ${s3Key}`);
+
+    // Create photo record in DB
+    const photo = await createOrUpdatePhoto({
+      folder_id: folder.id,
+      filename: file.name,
+      s3_key: s3Key,
+      size: buffer.length,
+      mime_type: mimeType,
+      modified_at: new Date().toISOString(),
+      metadata_status: "none",
+      thumbnail_status: "pending",
+    });
+
+    // Generate thumbnail in background (don't await)
+    thumbnailService
+      .generateThumbnail({
+        bucket,
+        s3Key,
+        photoId: photo.id,
+        request,
+      })
+      .catch((err) => {
+        logger.error(`Failed to generate thumbnail for photo ${photo.id}:`, err);
+      });
+
+    return NextResponse.json({
+      success: true,
+      photo: {
+        id: photo.id,
+        filename: photo.filename,
+        s3_key: photo.s3_key,
+        size: photo.size,
+        mime_type: photo.mime_type,
+      },
+    });
+  } catch (error) {
+    logger.apiError("Error in POST /api/photos/upload", error as Error, {
+      method: "POST",
+      path: "/api/photos/upload",
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Upload failed",
+      },
+      { status: 500 },
+    );
+  }
+});

--- a/src/app/folder/[[...path]]/page.tsx
+++ b/src/app/folder/[[...path]]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Folder, Photo } from "@/types";
 import FolderBrowser from "@/components/FolderBrowser";
 import PhotoGrid from "@/components/PhotoGrid";
+import UploadZone from "@/components/UploadZone";
 import AppLayout from "@/components/AppLayout";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -164,21 +165,33 @@ function FolderContent({ params }: FolderPageProps) {
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
           </div>
         ) : (
-          <div className="space-y-6">
-            <FolderBrowser
-              currentFolder={currentFolder}
-              folders={folders}
-              breadcrumbs={breadcrumbs}
-              onFolderSelect={navigateToFolder}
-              onBreadcrumbClick={navigateToBreadcrumb}
-            />
-            <PhotoGrid
-              photos={photos}
-              loading={loading}
-              selectedPhotoId={selectedPhotoId}
-              onPhotoUrlChange={handlePhotoUrlChange}
-            />
-          </div>
+          <UploadZone
+            folderPath={currentPath}
+            onUploadComplete={() => {
+              // Reload folder contents after upload
+              if (currentPath === "") {
+                loadRootFolders();
+              } else {
+                loadFolder(currentPath);
+              }
+            }}
+          >
+            <div className="space-y-6">
+              <FolderBrowser
+                currentFolder={currentFolder}
+                folders={folders}
+                breadcrumbs={breadcrumbs}
+                onFolderSelect={navigateToFolder}
+                onBreadcrumbClick={navigateToBreadcrumb}
+              />
+              <PhotoGrid
+                photos={photos}
+                loading={loading}
+                selectedPhotoId={selectedPhotoId}
+                onPhotoUrlChange={handlePhotoUrlChange}
+              />
+            </div>
+          </UploadZone>
         )}
       </ProtectedRoute>
     </AppLayout>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Folder, Photo } from "@/types";
 import FolderBrowser from "@/components/FolderBrowser";
 import PhotoGrid from "@/components/PhotoGrid";
+import UploadZone from "@/components/UploadZone";
 import RandomPhotosTeaser from "@/components/RandomPhotosTeaser";
 import AppLayout from "@/components/AppLayout";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
@@ -101,31 +102,33 @@ function HomePageContent() {
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
           </div>
         ) : (
-          <div className="space-y-6">
-            <FolderBrowser
-              currentFolder={currentFolder}
-              folders={folders}
-              breadcrumbs={breadcrumbs}
-              onFolderSelect={navigateToFolder}
-              onBreadcrumbClick={navigateToBreadcrumb}
-            />
+          <UploadZone folderPath="" onUploadComplete={loadRootFolders}>
+            <div className="space-y-6">
+              <FolderBrowser
+                currentFolder={currentFolder}
+                folders={folders}
+                breadcrumbs={breadcrumbs}
+                onFolderSelect={navigateToFolder}
+                onBreadcrumbClick={navigateToBreadcrumb}
+              />
 
-            {/* Show photos in root if any exist */}
-            <PhotoGrid
-              photos={photos}
-              loading={loading}
-              selectedPhotoId={selectedPhotoId}
-              onPhotoUrlChange={handlePhotoUrlChange}
-            />
-
-            {/* Show random photos teaser when at root with folders but no photos */}
-            {showRandomPhotosTeaser && (
-              <RandomPhotosTeaser
+              {/* Show photos in root if any exist */}
+              <PhotoGrid
+                photos={photos}
+                loading={loading}
                 selectedPhotoId={selectedPhotoId}
                 onPhotoUrlChange={handlePhotoUrlChange}
               />
-            )}
-          </div>
+
+              {/* Show random photos teaser when at root with folders but no photos */}
+              {showRandomPhotosTeaser && (
+                <RandomPhotosTeaser
+                  selectedPhotoId={selectedPhotoId}
+                  onPhotoUrlChange={handlePhotoUrlChange}
+                />
+              )}
+            </div>
+          </UploadZone>
         )}
       </ProtectedRoute>
     </AppLayout>

--- a/src/components/PhotoGrid.tsx
+++ b/src/components/PhotoGrid.tsx
@@ -13,6 +13,7 @@ interface PhotoGridProps {
   loading?: boolean;
   selectedPhotoId?: string | null;
   onPhotoUrlChange?: (photoId: string | null) => void;
+  onPhotoDeleted?: (photo: Photo) => void;
   isSharedView?: boolean;
   shareToken?: string;
   allowDownload?: boolean;
@@ -24,6 +25,7 @@ export default function PhotoGrid({
   loading = false,
   selectedPhotoId,
   onPhotoUrlChange,
+  onPhotoDeleted,
   isSharedView = false,
   shareToken,
   allowDownload = true,
@@ -86,6 +88,16 @@ export default function PhotoGrid({
   const handlePhotoClose = () => {
     setSelectedPhoto(null);
     onPhotoUrlChange?.(null);
+  };
+
+  // Handle photo deletion
+  const handlePhotoDelete = (deletedPhoto: Photo) => {
+    // Remove from local state immediately
+    setPhotosState((prevPhotos) =>
+      prevPhotos.filter((p) => p.id !== deletedPhoto.id)
+    );
+    // Notify parent if callback provided
+    onPhotoDeleted?.(deletedPhoto);
   };
 
   const toggleFavorite = async (photo: Photo, event: React.MouseEvent) => {
@@ -177,7 +189,7 @@ export default function PhotoGrid({
       >
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-medium text-gray-900">
-            Media ({photos.length})
+            Media ({photosState.length})
           </h2>
           <button
             onClick={() => setIsFullWidth(!isFullWidth)}
@@ -240,6 +252,7 @@ export default function PhotoGrid({
             setSelectedPhoto(newPhoto);
             onPhotoUrlChange?.(newPhoto.id.toString());
           }}
+          onDelete={!isSharedView ? handlePhotoDelete : undefined}
           isSharedView={isSharedView}
           shareToken={shareToken}
           allowDownload={allowDownload}

--- a/src/components/PhotoViewerControls.tsx
+++ b/src/components/PhotoViewerControls.tsx
@@ -8,6 +8,7 @@ import {
   Pause,
   Expand,
   Minimize2,
+  Trash2,
 } from "lucide-react";
 
 interface PhotoViewerControlsProps {
@@ -39,6 +40,10 @@ interface PhotoViewerControlsProps {
   onDownload: () => void;
   /** Handle close */
   onClose: () => void;
+  /** Handle delete */
+  onDelete?: () => void;
+  /** Whether delete operation is in progress */
+  deleteLoading?: boolean;
 }
 
 export default function PhotoViewerControls({
@@ -56,6 +61,8 @@ export default function PhotoViewerControls({
   allowDownload,
   onDownload,
   onClose,
+  onDelete,
+  deleteLoading,
 }: PhotoViewerControlsProps) {
   return (
     <div className="flex items-center space-x-2 flex-shrink-0 ml-4">
@@ -146,6 +153,24 @@ export default function PhotoViewerControls({
           title="Download original"
         >
           <Download className="w-5 h-5" />
+        </button>
+      )}
+
+      {/* Delete button - only show in regular view */}
+      {!isSharedView && onDelete && (
+        <button
+          onClick={onDelete}
+          disabled={deleteLoading}
+          className={`p-2 hover:bg-red-500 hover:bg-opacity-30 rounded-lg transition-colors ${
+            deleteLoading ? "opacity-50 cursor-not-allowed" : ""
+          }`}
+          title={deleteLoading ? "Deleting..." : "Delete photo (Del)"}
+        >
+          {deleteLoading ? (
+            <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+          ) : (
+            <Trash2 className="w-5 h-5 text-white hover:text-red-400" />
+          )}
         </button>
       )}
 

--- a/src/components/UploadZone.tsx
+++ b/src/components/UploadZone.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useState, useRef, useCallback, ReactNode } from "react";
+import { Upload, X, CheckCircle, AlertCircle, FileImage } from "lucide-react";
+
+// Client-side media file validation (can't import from s3.ts - it uses Node modules)
+const MEDIA_EXTENSIONS = new Set([
+  // Images
+  ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".tiff", ".tif", ".svg",
+  ".nef", ".cr2", ".cr3", ".arw", ".dng", ".raf", ".orf", ".rw2", ".pef", ".srw", ".x3f",
+  ".heic", ".heif", ".avif",
+  // Videos
+  ".mp4", ".m4v", ".mov", ".avi", ".wmv", ".mkv", ".webm", ".flv", ".ogv",
+  ".3gp", ".3g2", ".mts", ".m2ts", ".ts",
+]);
+
+function isMediaFile(filename: string): boolean {
+  const ext = filename.toLowerCase().substring(filename.lastIndexOf("."));
+  return MEDIA_EXTENSIONS.has(ext);
+}
+
+interface UploadFile {
+  id: string;
+  file: File;
+  status: "pending" | "uploading" | "success" | "error";
+  progress: number;
+  error?: string;
+}
+
+interface UploadZoneProps {
+  folderPath: string;
+  onUploadComplete?: () => void;
+  children: ReactNode;
+}
+
+export default function UploadZone({
+  folderPath,
+  onUploadComplete,
+  children,
+}: UploadZoneProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploads, setUploads] = useState<UploadFile[]>([]);
+  const [showPanel, setShowPanel] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragCounter = useRef(0);
+
+  const addFiles = useCallback((files: FileList | File[]) => {
+    const validFiles = Array.from(files).filter((file) =>
+      isMediaFile(file.name)
+    );
+
+    if (validFiles.length === 0) return;
+
+    const newUploads: UploadFile[] = validFiles.map((file) => ({
+      id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      file,
+      status: "pending",
+      progress: 0,
+    }));
+
+    setUploads((prev) => [...prev, ...newUploads]);
+    setShowPanel(true);
+
+    // Start uploading each file
+    newUploads.forEach((upload) => uploadFile(upload));
+  }, [folderPath]);
+
+  const uploadFile = async (upload: UploadFile) => {
+    setUploads((prev) =>
+      prev.map((u) =>
+        u.id === upload.id ? { ...u, status: "uploading" } : u
+      )
+    );
+
+    try {
+      const formData = new FormData();
+      formData.append("file", upload.file);
+      formData.append("folder", folderPath);
+
+      const response = await fetch("/api/photos/upload", {
+        method: "POST",
+        body: formData,
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Upload failed");
+      }
+
+      setUploads((prev) =>
+        prev.map((u) =>
+          u.id === upload.id ? { ...u, status: "success", progress: 100 } : u
+        )
+      );
+
+      // Call onUploadComplete when a file is successfully uploaded
+      if (onUploadComplete) {
+        onUploadComplete();
+      }
+    } catch (error) {
+      setUploads((prev) =>
+        prev.map((u) =>
+          u.id === upload.id
+            ? {
+                ...u,
+                status: "error",
+                error: error instanceof Error ? error.message : "Upload failed",
+              }
+            : u
+        )
+      );
+    }
+  };
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current++;
+    if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+      setIsDragging(true);
+    }
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current--;
+    if (dragCounter.current === 0) {
+      setIsDragging(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+      dragCounter.current = 0;
+
+      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        addFiles(e.dataTransfer.files);
+      }
+    },
+    [addFiles]
+  );
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files && e.target.files.length > 0) {
+        addFiles(e.target.files);
+        // Reset input so same file can be selected again
+        e.target.value = "";
+      }
+    },
+    [addFiles]
+  );
+
+  const removeUpload = useCallback((id: string) => {
+    setUploads((prev) => prev.filter((u) => u.id !== id));
+  }, []);
+
+  const clearCompleted = useCallback(() => {
+    setUploads((prev) => prev.filter((u) => u.status !== "success"));
+  }, []);
+
+  const pendingCount = uploads.filter((u) => u.status === "pending" || u.status === "uploading").length;
+  const successCount = uploads.filter((u) => u.status === "success").length;
+  const errorCount = uploads.filter((u) => u.status === "error").length;
+
+  return (
+    <div
+      className="relative"
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept="image/*,video/*"
+        onChange={handleFileSelect}
+        className="hidden"
+      />
+
+      {/* Upload Button */}
+      <div className="mb-4 flex items-center gap-3">
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-lg transition-colors"
+        >
+          <Upload className="w-4 h-4" />
+          Upload Photos
+        </button>
+        {uploads.length > 0 && (
+          <button
+            onClick={() => setShowPanel(!showPanel)}
+            className="flex items-center gap-2 px-3 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors text-sm"
+          >
+            {pendingCount > 0 && (
+              <span className="flex items-center gap-1">
+                <div className="w-3 h-3 border-2 border-primary-600 border-t-transparent rounded-full animate-spin" />
+                {pendingCount}
+              </span>
+            )}
+            {successCount > 0 && (
+              <span className="flex items-center gap-1 text-green-600">
+                <CheckCircle className="w-3 h-3" />
+                {successCount}
+              </span>
+            )}
+            {errorCount > 0 && (
+              <span className="flex items-center gap-1 text-red-600">
+                <AlertCircle className="w-3 h-3" />
+                {errorCount}
+              </span>
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Drag Overlay */}
+      {isDragging && (
+        <div className="fixed inset-0 bg-primary-600 bg-opacity-20 z-50 flex items-center justify-center pointer-events-none">
+          <div className="bg-white rounded-2xl shadow-2xl p-12 flex flex-col items-center gap-4 border-4 border-dashed border-primary-500">
+            <Upload className="w-16 h-16 text-primary-600" />
+            <p className="text-xl font-semibold text-gray-800">
+              Drop photos here to upload
+            </p>
+            <p className="text-gray-500">
+              to <span className="font-medium">{folderPath || "root"}</span>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Upload Progress Panel */}
+      {showPanel && uploads.length > 0 && (
+        <div className="fixed bottom-4 right-4 w-96 bg-white rounded-lg shadow-xl border z-40 max-h-96 overflow-hidden flex flex-col">
+          <div className="flex items-center justify-between px-4 py-3 border-b bg-gray-50">
+            <span className="font-medium text-gray-800">
+              Uploads ({uploads.length})
+            </span>
+            <div className="flex items-center gap-2">
+              {successCount > 0 && (
+                <button
+                  onClick={clearCompleted}
+                  className="text-xs text-gray-500 hover:text-gray-700"
+                >
+                  Clear completed
+                </button>
+              )}
+              <button
+                onClick={() => setShowPanel(false)}
+                className="p-1 hover:bg-gray-200 rounded"
+              >
+                <X className="w-4 h-4 text-gray-500" />
+              </button>
+            </div>
+          </div>
+          <div className="overflow-y-auto flex-1">
+            {uploads.map((upload) => (
+              <div
+                key={upload.id}
+                className="flex items-center gap-3 px-4 py-3 border-b last:border-b-0"
+              >
+                <FileImage className="w-8 h-8 text-gray-400 flex-shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-800 truncate">
+                    {upload.file.name}
+                  </p>
+                  {upload.status === "uploading" && (
+                    <div className="w-full bg-gray-200 rounded-full h-1.5 mt-1">
+                      <div className="bg-primary-600 h-1.5 rounded-full animate-pulse w-1/2" />
+                    </div>
+                  )}
+                  {upload.status === "error" && (
+                    <p className="text-xs text-red-500 truncate">
+                      {upload.error}
+                    </p>
+                  )}
+                </div>
+                <div className="flex-shrink-0">
+                  {upload.status === "pending" && (
+                    <div className="w-5 h-5 border-2 border-gray-300 border-t-primary-600 rounded-full animate-spin" />
+                  )}
+                  {upload.status === "uploading" && (
+                    <div className="w-5 h-5 border-2 border-gray-300 border-t-primary-600 rounded-full animate-spin" />
+                  )}
+                  {upload.status === "success" && (
+                    <CheckCircle className="w-5 h-5 text-green-500" />
+                  )}
+                  {upload.status === "error" && (
+                    <button onClick={() => removeUpload(upload.id)}>
+                      <AlertCircle className="w-5 h-5 text-red-500" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Children (gallery content) */}
+      {children}
+    </div>
+  );
+}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -503,6 +503,14 @@ export async function getPhoto(photoId: number): Promise<Photo | null> {
   return normalizePhoto(photo);
 }
 
+export async function deletePhoto(photoId: number): Promise<boolean> {
+  const result = await query(
+    "DELETE FROM photos WHERE id = $1 RETURNING id",
+    [photoId],
+  );
+  return result.rowCount !== null && result.rowCount > 0;
+}
+
 export async function createSyncJob(
   jobData: CreateSyncJobData,
 ): Promise<SyncJob> {


### PR DESCRIPTION
Gallery was read-only — users couldn't add or remove photos without direct S3 access.

Adds upload via drag & drop anywhere on the gallery or classic file picker button. Delete from PhotoViewer with confirmation dialog (also Del/Backspace keyboard shortcut). Both operations use existing S3 audit middleware for logging.

**Changes:**
- `POST /api/photos/upload` — multipart form upload to Backblaze B2, creates DB record, triggers thumbnail generation
- `DELETE /api/photos/[id]` — removes from S3, R2 thumbnail storage, and database
- `UploadZone` component wraps gallery with drag & drop overlay and progress panel
- Delete button + confirmation dialog in PhotoViewer

**Note:** Requires Backblaze API key with `writeFiles` and `deleteFiles` capabilities (previously read-only was sufficient).